### PR TITLE
Adjust JWT authority extraction for realm roles

### DIFF
--- a/backend/src/main/java/com/festivo/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/festivo/common/security/SecurityConfig.java
@@ -1,13 +1,15 @@
 package com.festivo.common.security;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Set;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
@@ -46,11 +48,11 @@ public class SecurityConfig {
         Optional.ofNullable(jwt.getClaimAsMap(REALM_ACCESS))
             .map(claim -> (Collection<String>) claim.get(ROLES))
             .orElseGet(java.util.List::of);
-    var mappedRoles =
-        realmRoles.stream()
-            .map(role -> "ROLE_" + role.toUpperCase())
-            .map(org.springframework.security.core.authority.SimpleGrantedAuthority::new)
-            .collect(Collectors.toSet());
+    Set<GrantedAuthority> mappedRoles = new HashSet<>();
+    realmRoles.stream()
+        .map(role -> "ROLE_" + role.toUpperCase())
+        .map(SimpleGrantedAuthority::new)
+        .forEach(mappedRoles::add);
     if (authorities != null) {
       mappedRoles.addAll(authorities);
     }


### PR DESCRIPTION
## Summary
- collect realm roles into a GrantedAuthority set to avoid narrowing casts
- merge the delegate authorities directly into the accumulated set

## Testing
- `./mvnw -DskipTests package` *(fails: could not download parent POM due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d6389364088320b45d20f847e30cc9