### PR TITLE
Add Vite React plugin dev dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- add @vitejs/plugin-react to the frontend devDependencies so the existing Vite config can resolve the plugin

## Testing
- npm run build *(fails: missing local type dependencies because npm install could not run due to 403 responses from the registry)*

------
https://chatgpt.com/codex/tasks/task_b_68d644e414c8832098bcf7f9672412ee