### PR TITLE
Fix MySQL health check configuration

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,10 +15,11 @@ services:
       - festivo-db-data:/var/lib/mysql
       - ../scripts/db/seed.sql:/docker-entrypoint-initdb.d/seed.sql:ro
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-pfestivo_root"]
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p$$MYSQL_ROOT_PASSWORD || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10
+      start_period: 30s
 
   keycloak:
     image: quay.io/keycloak/keycloak:24.0


### PR DESCRIPTION
## Summary
- update the MySQL container healthcheck to reuse the configured root password instead of a hard-coded value
- ping the database over TCP and add a start period so the health check does not fail during startup

## Testing
- not run (Docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d647261ae083208bf97a0f61ba9c9e