### PR TITLE
Improve MySQL health check robustness

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,10 +15,11 @@ services:
       - festivo-db-data:/var/lib/mysql
       - ../scripts/db/seed.sql:/docker-entrypoint-initdb.d/seed.sql:ro
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-pfestivo_root"]
+      test: ["CMD-SHELL", "set -e; mysqladmin --protocol=TCP ping -h 127.0.0.1 -uroot --password=\"$$MYSQL_ROOT_PASSWORD\" --silent"]
       interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 12
+      start_period: 60s
 
   keycloak:
     image: quay.io/keycloak/keycloak:24.0


### PR DESCRIPTION
## Summary
- harden the MySQL health check to use TCP, honor the configured root password, and run silently under the shell
- give the database extra retries and start-up time so the container can report healthy before dependents start

## Testing
- not run (Docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68d647261ae083208bf97a0f61ba9c9e