### PR TITLE
Fix MySQL 8.4 compose command

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-festivo_root}
     ports:
       - "3306:3306"
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - festivo-db-data:/var/lib/mysql
       - ../scripts/db/seed.sql:/docker-entrypoint-initdb.d/seed.sql:ro


### PR DESCRIPTION
## Summary
- remove the deprecated mysql_native_password authentication flag from the db service command so the MySQL 8.4 container starts successfully

## Testing
- not run (Docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d64cb071748320b2d57b47ce5775fc