### PR TITLE
Fix Keycloak hostname config and JWT issuer property

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
     open-in-view: false
   jackson:
     time-zone: UTC
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${OIDC_ISSUER_URI:http://localhost:8081/realms/festivo}
 
 server:
   port: ${SERVER_PORT:8080}
@@ -36,9 +41,3 @@ festivo:
 logging:
   level:
     org.springframework.security: INFO
-
-security:
-  oauth2:
-    resourceserver:
-      jwt:
-        issuer-uri: ${OIDC_ISSUER_URI:http://localhost:8081/realms/festivo}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_HTTP_PORT: 8081
-      KC_HOSTNAME: localhost
       KC_HOSTNAME_URL: ${KEYCLOAK_FRONTEND_URL:-http://localhost:8081}
       KC_PROXY: edge
       KC_HOSTNAME_STRICT: "false"


### PR DESCRIPTION
## Summary
- remove the conflicting KC_HOSTNAME override from the Keycloak Docker service so the container starts in dev
- place the resource server issuer configuration under spring.security so Spring Boot can auto-configure the JwtDecoder

## Testing
- `./mvnw test` *(fails: Unable to download dependencies from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d654a279848320a43dafba76c5315b