### PR TITLE
Handle dashboard load errors

### DIFF
--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,21 +1,56 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { apiClient } from '../../shared/api/client';
 import { CenteredSpinner } from '../../shared/components/CenteredSpinner';
 
 const organizerId = 1; // Demo seed user
 
 export const DashboardPage: React.FC = () => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ['dashboard', organizerId],
     queryFn: async () => {
       const response = await apiClient.get('/api/dashboard', { params: { organizerId } });
       return response.data as { upcoming: Array<any>; counts: { totalBookings: number; payments: number } };
-    }
+    },
+    retry: false
   });
 
-  if (isLoading || !data) {
+  if (isLoading) {
     return <CenteredSpinner label="Fetching planner dashboard" />;
+  }
+
+  if (isError) {
+    const message = deriveErrorMessage(error);
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '1.5rem',
+          borderRadius: '1rem',
+          boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)'
+        }}
+      >
+        <h2 style={{ marginBottom: '0.5rem', fontSize: '1.25rem' }}>Unable to load your dashboard</h2>
+        <p style={{ margin: 0, color: '#64748b' }}>{message}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '1.5rem',
+          borderRadius: '1rem',
+          boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)'
+        }}
+      >
+        <h2 style={{ marginBottom: '0.5rem', fontSize: '1.25rem' }}>Dashboard data unavailable</h2>
+        <p style={{ margin: 0, color: '#64748b' }}>We couldn&apos;t find any dashboard data to display.</p>
+      </div>
+    );
   }
 
   return (
@@ -49,3 +84,26 @@ const MetricCard: React.FC<{ title: string; value: number }> = ({ title, value }
     <div style={{ fontSize: '2rem', fontWeight: 700 }}>{value}</div>
   </div>
 );
+
+const deriveErrorMessage = (error: unknown) => {
+  if (isAxiosError(error)) {
+    if (error.response?.status === 403) {
+      return 'You do not have permission to view this dashboard. Try signing in with an organizer account.';
+    }
+
+    const responseMessage =
+      (typeof error.response?.data === 'string' && error.response.data) ||
+      (error.response?.data && typeof (error.response.data as any).message === 'string'
+        ? (error.response.data as any).message
+        : undefined);
+    if (responseMessage) {
+      return responseMessage;
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return 'Something went wrong while loading the dashboard. Please try again later.';
+};


### PR DESCRIPTION
## Summary
- surface API failures on the dashboard instead of leaving the loading spinner active
- provide clear, user-friendly messaging for unauthorized and unexpected dashboard errors
- return a fallback view when no dashboard data is available and prevent unnecessary retries

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file under ESLint 9)*

------
https://chatgpt.com/codex/tasks/task_b_68d664399a1083208e47b0d1e42620c0