### PR TITLE
Fix frontend build issues for Chakra updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/frontend/src/features/vendor/VendorSchedulePage.tsx
+++ b/frontend/src/features/vendor/VendorSchedulePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Badge,
@@ -42,9 +42,14 @@ export const VendorSchedulePage: React.FC = () => {
     queryFn: async () => {
       const response = await apiClient.get<ScheduleBlock[]>(`/api/vendors/${vendorId}/schedule`);
       return response.data;
-    },
-    onSuccess: (data) => setPendingBlocks(data)
+    }
   });
+
+  useEffect(() => {
+    if (scheduleQuery.data) {
+      setPendingBlocks(scheduleQuery.data);
+    }
+  }, [scheduleQuery.data]);
 
   const updateMutation = useMutation({
     mutationFn: async (blocks: ScheduleBlock[]) => apiClient.put(`/api/vendors/${vendorId}/schedule`, blocks),

--- a/frontend/src/shared/components/AppLayout.tsx
+++ b/frontend/src/shared/components/AppLayout.tsx
@@ -78,10 +78,7 @@ export const AppLayout: React.FC = () => {
                 fontWeight="medium"
                 borderRadius="md"
                 _hover={{ textDecoration: 'none', bg: activeBg }}
-                style={({ isActive }) => ({
-                  backgroundColor: isActive ? 'rgba(255,255,255,0.2)' : undefined,
-                  color: '#fff'
-                })}
+                _activeLink={{ bg: activeBg, color: 'white' }}
               >
                 {item.label}
               </ChakraLink>


### PR DESCRIPTION
## Summary
- add the Chakra icons package required by the admin users page
- sync the vendor schedule form state from query results without deprecated callbacks
- rely on Chakra's active link styling helpers instead of NavLink style functions

## Testing
- npm install --no-audit --no-fund *(fails: 403 Forbidden fetching @chakra-ui/icons)*

------
https://chatgpt.com/codex/tasks/task_b_68d67a037f2c8320a0e82afab9dc88d2