### PR TITLE
Add configurable CORS support for backend APIs

### DIFF
--- a/backend/src/main/java/com/festivo/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/festivo/common/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -25,6 +26,7 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
+        .cors(Customizer.withDefaults())
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/actuator/health", "/api/ping", "/api/payments/callback").permitAll()

--- a/backend/src/main/java/com/festivo/common/web/CorsConfig.java
+++ b/backend/src/main/java/com/festivo/common/web/CorsConfig.java
@@ -1,0 +1,47 @@
+package com.festivo.common.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+  private static final String DEFAULT_ALLOWED_ORIGIN = "http://localhost";
+
+  @Value("${app.cors.allowed-origins:http://localhost,http://localhost:*}")
+  private String[] allowedOrigins;
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry
+            .addMapping("/**")
+            .allowedOriginPatterns(getAllowedOrigins())
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .exposedHeaders("Location")
+            .allowCredentials(true);
+      }
+    };
+  }
+
+  private String[] getAllowedOrigins() {
+    if (allowedOrigins == null || allowedOrigins.length == 0) {
+      return new String[] {DEFAULT_ALLOWED_ORIGIN};
+    }
+    var sanitized = java.util.Arrays.stream(allowedOrigins)
+        .filter(origin -> origin != null && !origin.isBlank())
+        .map(String::trim)
+        .toArray(String[]::new);
+    if (sanitized.length == 0) {
+      return new String[] {DEFAULT_ALLOWED_ORIGIN};
+    }
+    return sanitized;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a centralized WebMvcConfigurer to expose CORS headers for all backend endpoints with configurable allowed origins
- enable CORS handling in the Spring Security filter chain so preflight requests from the vendor portal succeed

## Testing
- `./mvnw test` *(fails: unable to download Maven dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d67fc14eec8320b08daa6f35988ff3