### PR TITLE
Fix default issuer URI for backend resource server

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${OIDC_ISSUER_URI:http://localhost:8081/realms/festivo}
+          issuer-uri: ${OIDC_ISSUER_URI:http://keycloak:8081/realms/festivo}
 
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
## Summary
- default the backend JWT issuer configuration to the Keycloak service hostname so containerized deployments resolve correctly

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper / blocked from Maven Central in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6824566b08320a389ea4194e51e39