### PR TITLE
Secure chat sender identification and event ownership

### DIFF
--- a/backend/src/main/java/com/festivo/events/EventController.java
+++ b/backend/src/main/java/com/festivo/events/EventController.java
@@ -1,9 +1,9 @@
 package com.festivo.events;
 
+import com.festivo.auth.CurrentUser;
 import com.festivo.common.security.Roles;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,8 @@ public class EventController {
 
   @PostMapping
   public Event create(@Valid @RequestBody EventRequest request) {
-    return eventService.create(request.customerId(), request.name(), request.description(), request.eventDate());
+    return eventService.create(
+        CurrentUser.subject(), request.name(), request.description(), request.eventDate());
   }
 
   @GetMapping("/{eventId}")
@@ -52,7 +53,6 @@ public class EventController {
   }
 
   public record EventRequest(
-      @NotNull Long customerId,
       @NotBlank String name,
       String description,
       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate eventDate) {}

--- a/backend/src/main/java/com/festivo/events/EventService.java
+++ b/backend/src/main/java/com/festivo/events/EventService.java
@@ -3,6 +3,8 @@ package com.festivo.events;
 import com.festivo.common.exception.ResourceNotFoundException;
 import com.festivo.users.Customer;
 import com.festivo.users.CustomerRepository;
+import com.festivo.users.User;
+import com.festivo.users.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.util.List;
@@ -15,11 +17,16 @@ import org.springframework.stereotype.Service;
 public class EventService {
   private final EventRepository eventRepository;
   private final CustomerRepository customerRepository;
+  private final UserRepository userRepository;
 
-  public Event create(Long customerId, String name, String description, LocalDate eventDate) {
+  public Event create(String customerExternalId, String name, String description, LocalDate eventDate) {
+    User user =
+        userRepository
+            .findByExternalId(customerExternalId)
+            .orElseThrow(() -> new ResourceNotFoundException("User not found"));
     Customer customer =
         customerRepository
-            .findById(customerId)
+            .findByUserId(user.getId())
             .orElseThrow(() -> new ResourceNotFoundException("Customer not found"));
 
     Event event = new Event();

--- a/backend/src/main/java/com/festivo/messaging/ChatController.java
+++ b/backend/src/main/java/com/festivo/messaging/ChatController.java
@@ -1,9 +1,9 @@
 package com.festivo.messaging;
 
+import com.festivo.auth.CurrentUser;
 import com.festivo.common.security.Roles;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class ChatController {
   @PostMapping("/booking/{bookingId}")
   @PreAuthorize("hasAnyAuthority('" + Roles.CUSTOMER + "','" + Roles.VENDOR + "','" + Roles.ADMIN + "')")
   public Message send(@PathVariable Long bookingId, @Valid @RequestBody MessageRequest request) {
-    return chatService.sendMessage(bookingId, request.senderId(), request.content());
+    return chatService.sendMessage(bookingId, CurrentUser.subject(), request.content());
   }
 
   @PostMapping("/messages/{messageId}/read")
@@ -40,5 +40,5 @@ public class ChatController {
     return Map.of("readAt", updated.getReadAt());
   }
 
-  public record MessageRequest(@NotNull Long senderId, @NotBlank String content) {}
+  public record MessageRequest(@NotBlank String content) {}
 }

--- a/backend/src/main/java/com/festivo/messaging/ChatService.java
+++ b/backend/src/main/java/com/festivo/messaging/ChatService.java
@@ -24,11 +24,11 @@ public class ChatService {
     return messageRepository.findByBookingIdOrderByCreatedAtAsc(bookingId);
   }
 
-  public Message sendMessage(Long bookingId, Long senderId, String content) {
+  public Message sendMessage(Long bookingId, String senderExternalId, String content) {
     Booking booking = bookingService.get(bookingId);
     User sender =
         userRepository
-            .findById(senderId)
+            .findByExternalId(senderExternalId)
             .orElseThrow(() -> new ResourceNotFoundException("Sender not found"));
     Message message = new Message();
     message.setBooking(booking);

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -37,7 +37,7 @@ export const App: React.FC = () => {
           <Route path="/events/:eventId/bookings" element={<BookingsPage />} />
           <Route path="/vendors" element={<VendorSearchPage />} />
           <Route path="/vendors/:vendorId" element={<VendorDetailPage />} />
-          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/chat/:bookingId" element={<ChatPage />} />
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route element={<ProtectedRoute roles={['ROLE_ADMIN']} />}>
             <Route path="/admin/dashboard" element={<AdminDashboardPage />} />

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -17,7 +17,6 @@ export const attachTokenInterceptor = (tokenSupplier: () => string | undefined) 
 };
 
 export type EventPayload = {
-  customerId: number;
   name: string;
   description?: string;
   eventDate?: string;


### PR DESCRIPTION
## Summary
- derive the chat message sender from the authenticated security context and resolve the user by external id
- associate newly created events with the logged-in customer via their external id
- update chat and event pages to pull ids from the router/auth context and remove hard-coded identifiers

## Testing
- ./mvnw test *(fails: unable to download Spring Boot parent POM due to HTTP 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_68d688e04f8083209b50a9ae926dff4a